### PR TITLE
Make badge image clickable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v2.0%20adopted-ff69b4.svg)
+[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v2.0%20adopted-ff69b4.svg)](https://github.com/SpineEventEngine/feedback/blob/master/CODE_OF_CONDUCT.md)
 
 # Feedback
 Framework feedback and developers' support


### PR DESCRIPTION
This PR adds a link to the badge in the `README` file that leads to the [`CODE_OF_CONDACT.md`](https://github.com/SpineEventEngine/feedback/blob/master/CODE_OF_CONDUCT.md) file.